### PR TITLE
replica: Fix string to int64 convertion in json

### DIFF
--- a/frontend/rest/model.go
+++ b/frontend/rest/model.go
@@ -14,8 +14,8 @@ type Volume struct {
 
 type ReadInput struct {
 	client.Resource
-	Offset int64 `json:"offset"`
-	Length int64 `json:"length"`
+	Offset int64 `json:"offset, string"`
+	Length int64 `json:"length, string"`
 }
 
 type ReadOutput struct {
@@ -85,11 +85,11 @@ func NewSchema() *client.Schemas {
 
 	volumes := schemas.AddType("volume", Volume{})
 	volumes.ResourceActions = map[string]client.Action{
-		"readat": client.Action{
+		"readat": {
 			Input:  "readInput",
 			Output: "readOutput",
 		},
-		"writeat": client.Action{
+		"writeat": {
 			Input:  "writeInput",
 			Output: "writeOutput",
 		},

--- a/replica/rest/model.go
+++ b/replica/rest/model.go
@@ -15,12 +15,12 @@ type Replica struct {
 	Head            string                      `json:"head"`
 	Parent          string                      `json:"parent"`
 	Size            string                      `json:"size"`
-	SectorSize      int64                       `json:"sectorSize"`
+	SectorSize      int64                       `json:"sectorSize, string"`
 	State           string                      `json:"state"`
 	Chain           []string                    `json:"chain"`
 	Disks           map[string]replica.DiskInfo `json:"disks"`
 	RemainSnapshots int                         `json:"remainsnapshots"`
-	RevisionCounter int64                       `json:"revisioncounter"`
+	RevisionCounter int64                       `json:"revisioncounter, string"`
 }
 
 type CreateInput struct {
@@ -75,7 +75,7 @@ type PrepareRemoveDiskOutput struct {
 
 type RevisionCounter struct {
 	client.Resource
-	Counter int64 `json:"counter"`
+	Counter int64 `json:"counter, string"`
 }
 
 func NewReplica(context *api.ApiContext, state replica.State, info replica.Info, rep *replica.Replica) *Replica {


### PR DESCRIPTION
int64 in json must be marked as ",string" in order to be parsed correctly

https://github.com/rancher/longhorn/issues/68

Also found out that it's no longer an issue in Go 1.8.3, but still.