### PR TITLE
package: Add engine-launcher

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 RUN apt-get update && apt-get install -y kmod curl nfs-common fuse \
         libibverbs1 librdmacm1 libconfig-general-perl libaio1
 
-COPY longhorn launch copy-binary launch-with-vm-backing-file launch-simple-longhorn longhorn-engine-launcher /usr/local/bin/
+COPY longhorn launch copy-binary launch-with-vm-backing-file launch-simple-longhorn longhorn-engine-launcher engine-launcher /usr/local/bin/
 COPY tgt_*.deb /opt/
 RUN dpkg -i /opt/tgt_*.deb
 VOLUME /usr/local/bin

--- a/package/engine-launcher
+++ b/package/engine-launcher
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+mount --rbind /host/dev /dev
+
+exec longhorn-engine-launcher "$@"


### PR DESCRIPTION
It will be used for bootstrap longhorn-engine-launcher, for tgt-blockdev and
tgt-iscsi.