### PR TITLE
Enable S3 support

### DIFF
--- a/replica/client/client.go
+++ b/replica/client/client.go
@@ -259,7 +259,7 @@ func (c *ReplicaClient) SendFile(from, host string, port int) error {
 	}
 }
 
-func (c *ReplicaClient) CreateBackup(snapshot, dest, volume string, labels []string) (string, error) {
+func (c *ReplicaClient) CreateBackup(snapshot, dest, volume string, labels []string, credential map[string]string) (string, error) {
 	var running agent.Process
 	err := c.post(c.syncAgent+"/processes", &agent.Process{
 		ProcessType: "backup",
@@ -267,6 +267,7 @@ func (c *ReplicaClient) CreateBackup(snapshot, dest, volume string, labels []str
 		DestFile:    dest,
 		Host:        volume,
 		Labels:      labels,
+		Credential:  credential,
 	}, &running)
 	if err != nil {
 		return "", err

--- a/sync/agent/model.go
+++ b/sync/agent/model.go
@@ -8,15 +8,16 @@ import (
 
 type Process struct {
 	client.Resource
-	ProcessType string    `json:"processType"`
-	SrcFile     string    `json:"srcFile"`
-	DestFile    string    `json:"destfile"`
-	Host        string    `json:"host"`
-	Port        int       `json:"port"`
-	ExitCode    int       `json:"exitCode"`
-	Output      string    `json:"output"`
-	Created     time.Time `json:"created"`
-	Labels      []string  `json:"labels"`
+	ProcessType string            `json:"processType"`
+	SrcFile     string            `json:"srcFile"`
+	DestFile    string            `json:"destfile"`
+	Host        string            `json:"host"`
+	Port        int               `json:"port"`
+	ExitCode    int               `json:"exitCode"`
+	Output      string            `json:"output"`
+	Created     time.Time         `json:"created"`
+	Labels      []string          `json:"labels"`
+	Credential  map[string]string `json:"credential"`
 }
 
 type ProcessCollection struct {

--- a/sync/backup.go
+++ b/sync/backup.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rancher/longhorn-engine/util"
 )
 
-func (t *Task) CreateBackup(snapshot, dest string, labels []string) (string, error) {
+func (t *Task) CreateBackup(snapshot, dest string, labels []string, credential map[string]string) (string, error) {
 	var replica *rest.Replica
 
 	if snapshot == VolumeHeadName {
@@ -38,14 +38,14 @@ func (t *Task) CreateBackup(snapshot, dest string, labels []string) (string, err
 		return "", fmt.Errorf("Cannot find a suitable replica for backup")
 	}
 
-	backup, err := t.createBackup(replica, snapshot, dest, volume.Name, labels)
+	backup, err := t.createBackup(replica, snapshot, dest, volume.Name, labels, credential)
 	if err != nil {
 		return "", err
 	}
 	return backup, nil
 }
 
-func (t *Task) createBackup(replicaInController *rest.Replica, snapshot, dest, volumeName string, labels []string) (string, error) {
+func (t *Task) createBackup(replicaInController *rest.Replica, snapshot, dest, volumeName string, labels []string, credential map[string]string) (string, error) {
 	if replicaInController.Mode != "RW" {
 		return "", fmt.Errorf("Can only create backup from replica in mode RW, got %s", replicaInController.Mode)
 	}
@@ -67,7 +67,7 @@ func (t *Task) createBackup(replicaInController *rest.Replica, snapshot, dest, v
 
 	logrus.Infof("Backing up %s on %s, to %s", snapshot, replicaInController.Address, dest)
 
-	backup, err := repClient.CreateBackup(snapshot, dest, volumeName, labels)
+	backup, err := repClient.CreateBackup(snapshot, dest, volumeName, labels, credential)
 	if err != nil {
 		logrus.Errorf("Failed backing up %s on %s to %s", snapshot, replicaInController.Address, dest)
 		return "", err

--- a/types/types.go
+++ b/types/types.go
@@ -9,6 +9,9 @@ const (
 
 	StateUp   = State("Up")
 	StateDown = State("Down")
+
+	AWSAccessKey = "AWS_ACCESS_KEY_ID"
+	AWSSecretKey = "AWS_SECRET_ACCESS_KEY"
 )
 
 type ReaderWriterAt interface {

--- a/util/util.go
+++ b/util/util.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"regexp"
@@ -225,4 +226,13 @@ func ExecuteWithTimeout(timeout time.Duration, binary string, args ...string) (s
 		return "", fmt.Errorf("Failed to execute: %v %v, output %v, error %v", binary, args, string(output), err)
 	}
 	return string(output), nil
+}
+
+func CheckBackupType(backupTarget string) (string, error) {
+	u, err := url.Parse(backupTarget)
+	if err != nil {
+		return "", err
+	}
+
+	return u.Scheme, nil
 }


### PR DESCRIPTION
To support S3 backup in longhorn-engine, we need to add aws credential parameters.
- Add aws credential parameter for backup command.
- Add validate s3 command for credential validation.