### PR TITLE
fix(golint): update go get url of golint

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -30,7 +30,7 @@ RUN rm -f /bin/sh && ln -s /bin/bash /bin/sh
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 RUN wget -O - https://storage.googleapis.com/golang/go1.8.3.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
-    go get github.com/rancher/trash && go get github.com/golang/lint/golint
+    go get github.com/rancher/trash && go get golang.org/x/lint/golint
 
 # Docker
 ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \


### PR DESCRIPTION
This commit update the url of golint to be installed while running
make.

Ref: https://stackoverflow.com/questions/52784861/cannot-install-golint-package-wrong-import-path

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>