### PR TITLE
Upgrade docker version

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -21,7 +21,7 @@ RUN apt-get update && \
     apt-get install -y cmake wget curl git less file \
         libglib2.0-dev libkmod-dev libnl-genl-3-dev linux-libc-dev pkg-config psmisc python-tox qemu-utils fuse python-dev \
         devscripts debhelper bash-completion librdmacm-dev libibverbs-dev xsltproc docbook-xsl \
-        libconfig-general-perl libaio-dev libc6-dev sg3-utils
+        libconfig-general-perl libaio-dev libc6-dev sg3-utils iptables libltdl7
 
 # needed for ${!var} substitution
 RUN rm -f /bin/sh && ln -s /bin/bash /bin/sh
@@ -29,15 +29,15 @@ RUN rm -f /bin/sh && ln -s /bin/bash /bin/sh
 # Install Go & tools
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
-RUN wget -O - https://storage.googleapis.com/golang/go1.8.3.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
-    go get github.com/rancher/trash && go get golang.org/x/lint/golint
+RUN wget -O - https://storage.googleapis.com/golang/go1.10.3.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
+    go get github.com/rancher/trash && go get -u golang.org/x/lint/golint
 
 # Docker
-ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
-    DOCKER_URL_arm=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm \
+ENV DOCKER_URL_amd64=https://download.docker.com/linux/ubuntu/dists/xenial/pool/stable/amd64/docker-ce_17.03.3~ce-0~ubuntu-xenial_amd64.deb \
+    DOCKER_URL_arm=https://download.docker.com/linux/ubuntu/dists/xenial/pool/stable/arm64/docker-ce_18.06.1~ce~3-0~ubuntu_arm64.deb \
     DOCKER_URL=DOCKER_URL_${ARCH}
 
-RUN wget -O /usr/bin/docker ${!DOCKER_URL} && chmod +x /usr/bin/docker
+RUN wget ${!DOCKER_URL} -O docker_ce_${ARCH} && dpkg -i docker_ce_${ARCH}
 
 # Minio
 RUN wget -O /usr/bin/minio https://dl.minio.io/server/minio/release/linux-amd64/archive/minio.RELEASE.2018-05-25T19-49-13Z && chmod +x /usr/bin/minio

--- a/backend/remote/remote.go
+++ b/backend/remote/remote.go
@@ -27,6 +27,10 @@ func New() types.BackendFactory {
 	return &Factory{}
 }
 
+type RevisionCounter struct {
+	Counter int64 `json:"counter,string"`
+}
+
 type Factory struct {
 }
 
@@ -135,7 +139,7 @@ func (r *Remote) GetRevisionCounter() (int64, error) {
 
 func (r *Remote) SetRevisionCounter(counter int64) error {
 	logrus.Infof("Set revision counter of %s to : %v", r.name, counter)
-	return r.doAction("setrevisioncounter", &map[string]int64{"counter": counter})
+	return r.doAction("setrevisioncounter", &RevisionCounter{Counter: counter})
 }
 
 func (r *Remote) info() (rest.Replica, error) {

--- a/frontend/rest/model.go
+++ b/frontend/rest/model.go
@@ -14,8 +14,8 @@ type Volume struct {
 
 type ReadInput struct {
 	client.Resource
-	Offset int64 `json:"offset, string"`
-	Length int64 `json:"length, string"`
+	Offset int64 `json:"offset,string"`
+	Length int64 `json:"length,string"`
 }
 
 type ReadOutput struct {

--- a/integration/core/test_cli.py
+++ b/integration/core/test_cli.py
@@ -115,7 +115,7 @@ def open_replica(client):
     r = replicas[0]
     assert r.state == 'initial'
     assert r.size == '0'
-    assert r.sectorSize == 0
+    assert r.sectorSize == '0'
     assert r.parent == ''
     assert r.head == ''
 
@@ -123,7 +123,7 @@ def open_replica(client):
 
     assert r.state == 'closed'
     assert r.size == str(1024 * 4096)
-    assert r.sectorSize == 512
+    assert r.sectorSize == '512'
     assert r.parent == ''
     assert r.head == 'volume-head-000.img'
 

--- a/integration/core/test_replica.py
+++ b/integration/core/test_replica.py
@@ -42,7 +42,7 @@ def test_create(client):
     r = replicas[0]
     assert r.state == 'initial'
     assert r.size == '0'
-    assert r.sectorSize == 0
+    assert r.sectorSize == '0'
     assert r.parent == ''
     assert r.head == ''
 
@@ -50,7 +50,7 @@ def test_create(client):
 
     assert r.state == 'closed'
     assert r.size == str(1024*4096)
-    assert r.sectorSize == 512
+    assert r.sectorSize == '512'
     assert r.parent == ''
     assert r.head == 'volume-head-000.img'
 
@@ -62,7 +62,7 @@ def test_open(client):
     r = replicas[0]
     assert r.state == 'initial'
     assert r.size == '0'
-    assert r.sectorSize == 0
+    assert r.sectorSize == '0'
     assert r.parent == ''
     assert r.head == ''
 
@@ -72,7 +72,7 @@ def test_open(client):
     assert not r.dirty
     assert not r.rebuilding
     assert r.size == str(1024*4096)
-    assert r.sectorSize == 512
+    assert r.sectorSize == '512'
     assert r.parent == ''
     assert r.head == 'volume-head-000.img'
 
@@ -82,7 +82,7 @@ def test_open(client):
     assert not r.dirty
     assert not r.rebuilding
     assert r.size == str(1024*4096)
-    assert r.sectorSize == 512
+    assert r.sectorSize == '512'
     assert r.parent == ''
     assert r.head == 'volume-head-000.img'
 
@@ -99,7 +99,7 @@ def test_close(client):
     assert not r.dirty
     assert not r.rebuilding
     assert r.size == str(1024*4096)
-    assert r.sectorSize == 512
+    assert r.sectorSize == '512'
     assert r.parent == ''
     assert r.head == 'volume-head-000.img'
 
@@ -109,7 +109,7 @@ def test_close(client):
     assert not r.dirty
     assert not r.rebuilding
     assert r.size == str(1024*4096)
-    assert r.sectorSize == 512
+    assert r.sectorSize == '512'
     assert r.parent == ''
     assert r.head == 'volume-head-000.img'
 
@@ -126,7 +126,7 @@ def test_snapshot(client):
     assert not r.dirty
     assert not r.rebuilding
     assert r.size == str(1024*4096)
-    assert r.sectorSize == 512
+    assert r.sectorSize == '512'
     assert r.parent == ''
     assert r.head == 'volume-head-000.img'
 
@@ -136,7 +136,7 @@ def test_snapshot(client):
     assert r.dirty
     assert not r.rebuilding
     assert r.size == str(1024*4096)
-    assert r.sectorSize == 512
+    assert r.sectorSize == '512'
     assert r.disks["volume-snap-000.img"].labels["name"] == "000"
     assert r.disks["volume-snap-000.img"].labels["key"] == "value"
 
@@ -146,7 +146,7 @@ def test_snapshot(client):
     assert r.dirty
     assert not r.rebuilding
     assert r.size == str(1024*4096)
-    assert r.sectorSize == 512
+    assert r.sectorSize == '512'
     assert r.head == 'volume-head-002.img'
     assert r.parent == 'volume-snap-001.img'
     assert r.chain == ['volume-head-002.img', 'volume-snap-001.img',
@@ -189,7 +189,7 @@ def test_remove_disk(client):
     assert r.state == 'dirty'
     assert not r.rebuilding
     assert r.size == str(1024*4096)
-    assert r.sectorSize == 512
+    assert r.sectorSize == '512'
     assert r.head == 'volume-head-002.img'
     assert r.parent == 'volume-snap-000.img'
     assert r.chain == ['volume-head-002.img', 'volume-snap-000.img']
@@ -221,7 +221,7 @@ def test_remove_last_disk(client):
     assert r.state == 'dirty'
     assert not r.rebuilding
     assert r.size == str(1024*4096)
-    assert r.sectorSize == 512
+    assert r.sectorSize == '512'
     assert r.head == 'volume-head-002.img'
     assert r.parent == 'volume-snap-001.img'
     assert r.chain == ['volume-head-002.img', 'volume-snap-001.img']
@@ -244,7 +244,7 @@ def test_reload(client):
     r = r.removedisk(name='volume-snap-000.img')
     assert r.state == 'dirty'
     assert r.size == str(1024*4096)
-    assert r.sectorSize == 512
+    assert r.sectorSize == '512'
     assert r.head == 'volume-head-002.img'
     assert r.parent == 'volume-snap-001.img'
     assert r.chain == ['volume-head-002.img', 'volume-snap-001.img']
@@ -252,7 +252,7 @@ def test_reload(client):
     r = r.reload()
     assert r.state == 'dirty'
     assert r.size == str(1024*4096)
-    assert r.sectorSize == 512
+    assert r.sectorSize == '512'
     assert r.chain == ['volume-head-002.img', 'volume-snap-001.img']
     assert r.head == 'volume-head-002.img'
     assert r.parent == 'volume-snap-001.img'
@@ -260,7 +260,7 @@ def test_reload(client):
     r = r.close().open()
     assert r.state == 'open'
     assert r.size == str(1024*4096)
-    assert r.sectorSize == 512
+    assert r.sectorSize == '512'
     assert r.chain == ['volume-head-002.img', 'volume-snap-001.img']
     assert r.head == 'volume-head-002.img'
     assert r.parent == 'volume-snap-001.img'
@@ -276,14 +276,14 @@ def test_reload_simple(client):
     assert r.state == 'open'
     assert not r.rebuilding
     assert r.size == str(1024*4096)
-    assert r.sectorSize == 512
+    assert r.sectorSize == '512'
     assert r.parent == ''
     assert r.head == 'volume-head-000.img'
 
     r = r.reload()
     assert r.state == 'open'
     assert r.size == str(1024*4096)
-    assert r.sectorSize == 512
+    assert r.sectorSize == '512'
     assert r.parent == ''
     assert r.head == 'volume-head-000.img'
 
@@ -299,7 +299,7 @@ def test_rebuilding(client):
     assert r.state == 'dirty'
     assert not r.rebuilding
     assert r.size == str(1024*4096)
-    assert r.sectorSize == 512
+    assert r.sectorSize == '512'
     assert r.parent == 'volume-snap-001.img'
     assert r.head == 'volume-head-001.img'
     assert r.chain == ['volume-head-001.img', 'volume-snap-001.img']
@@ -308,7 +308,7 @@ def test_rebuilding(client):
     assert r.state == 'rebuilding'
     assert r.rebuilding
     assert r.size == str(1024*4096)
-    assert r.sectorSize == 512
+    assert r.sectorSize == '512'
     assert r.parent == 'volume-snap-001.img'
     assert r.head == 'volume-head-001.img'
     assert r.chain == ['volume-head-001.img', 'volume-snap-001.img']
@@ -317,7 +317,7 @@ def test_rebuilding(client):
     assert r.state == 'rebuilding'
     assert r.rebuilding
     assert r.size == str(1024*4096)
-    assert r.sectorSize == 512
+    assert r.sectorSize == '512'
     assert r.parent == 'volume-snap-001.img'
     assert r.head == 'volume-head-001.img'
     assert r.chain == ['volume-head-001.img', 'volume-snap-001.img']
@@ -326,7 +326,7 @@ def test_rebuilding(client):
     assert r.state == 'rebuilding'
     assert r.rebuilding
     assert r.size == str(1024*4096)
-    assert r.sectorSize == 512
+    assert r.sectorSize == '512'
     assert r.parent == 'volume-snap-001.img'
     assert r.head == 'volume-head-001.img'
     assert r.chain == ['volume-head-001.img', 'volume-snap-001.img']
@@ -343,7 +343,7 @@ def test_not_rebuilding(client):
     assert r.state == 'dirty'
     assert not r.rebuilding
     assert r.size == str(1024*4096)
-    assert r.sectorSize == 512
+    assert r.sectorSize == '512'
     assert r.parent == 'volume-snap-001.img'
     assert r.head == 'volume-head-001.img'
     assert r.chain == ['volume-head-001.img', 'volume-snap-001.img']
@@ -352,7 +352,7 @@ def test_not_rebuilding(client):
     assert r.state == 'rebuilding'
     assert r.rebuilding
     assert r.size == str(1024*4096)
-    assert r.sectorSize == 512
+    assert r.sectorSize == '512'
     assert r.parent == 'volume-snap-001.img'
     assert r.head == 'volume-head-001.img'
     assert r.chain == ['volume-head-001.img', 'volume-snap-001.img']
@@ -361,7 +361,7 @@ def test_not_rebuilding(client):
     assert r.state == 'dirty'
     assert not r.rebuilding
     assert r.size == str(1024*4096)
-    assert r.sectorSize == 512
+    assert r.sectorSize == '512'
     assert r.parent == 'volume-snap-001.img'
     assert r.head == 'volume-head-001.img'
     assert r.chain == ['volume-head-001.img', 'volume-snap-001.img']

--- a/integration/data/common.py
+++ b/integration/data/common.py
@@ -133,7 +133,7 @@ def open_replica(client, backing_file=None):
     r = replicas[0]
     assert r.state == 'initial'
     assert r.size == '0'
-    assert r.sectorSize == 0
+    assert r.sectorSize == '0'
     assert r.parent == ''
     assert r.head == ''
 
@@ -141,7 +141,7 @@ def open_replica(client, backing_file=None):
 
     assert r.state == 'closed'
     assert r.size == str(1024 * 4096)
-    assert r.sectorSize == 512
+    assert r.sectorSize == '512'
     assert r.parent == ''
     assert r.head == 'volume-head-000.img'
 

--- a/integration/data/test_ha.py
+++ b/integration/data/test_ha.py
@@ -132,7 +132,7 @@ def test_ha_double_replica_rebuild(controller, replica1, replica2):  # NOQA
 
     # Close replica2
     r2 = replica2.list_replica()[0]
-    assert r2.revisioncounter == 1
+    assert r2.revisioncounter == '1'
     r2.close()
 
     verify_async(dev, 10, 128, 1)
@@ -147,7 +147,7 @@ def test_ha_double_replica_rebuild(controller, replica1, replica2):  # NOQA
 
     # Close replica1
     r1 = replica1.list_replica()[0]
-    assert r1.revisioncounter == 12  # 1 + 10 + 1
+    assert r1.revisioncounter == '12'  # 1 + 10 + 1
     r1.close()
 
     # Restart volume
@@ -175,7 +175,7 @@ def test_ha_double_replica_rebuild(controller, replica1, replica2):  # NOQA
 
     # Rebuild replica2
     r2 = replica2.list_replica()[0]
-    assert r2.revisioncounter == 1
+    assert r2.revisioncounter == '1'
     r2.close()
 
     controller.delete(replicas[0])
@@ -191,8 +191,8 @@ def test_ha_double_replica_rebuild(controller, replica1, replica2):  # NOQA
 
     r1 = replica1.list_replica()[0]
     r2 = replica2.list_replica()[0]
-    assert r1.revisioncounter == 22  # 1 + 10 + 1 + 10
-    assert r2.revisioncounter == 22  # must be in sync with r1
+    assert r1.revisioncounter == '22'  # 1 + 10 + 1 + 10
+    assert r2.revisioncounter == '22'  # must be in sync with r1
 
 
 def test_ha_revision_counter_consistency(controller, replica1, replica2):  # NOQA
@@ -221,7 +221,7 @@ def test_ha_revision_counter_consistency(controller, replica1, replica2):  # NOQ
     r1 = replica1.list_replica()[0]
     r2 = replica2.list_replica()[0]
     # kernel can merge requests so backend may not receive 1000 writes
-    assert r1.revisioncounter > 0
+    assert r1.revisioncounter > '0'
     assert r1.revisioncounter == r2.revisioncounter
 
 

--- a/replica/rest/model.go
+++ b/replica/rest/model.go
@@ -15,13 +15,13 @@ type Replica struct {
 	Head            string                      `json:"head"`
 	Parent          string                      `json:"parent"`
 	Size            string                      `json:"size"`
-	SectorSize      int64                       `json:"sectorSize, string"`
+	SectorSize      int64                       `json:"sectorSize,string"`
 	BackingFile     string                      `json:"backingFile"`
 	State           string                      `json:"state"`
 	Chain           []string                    `json:"chain"`
 	Disks           map[string]replica.DiskInfo `json:"disks"`
 	RemainSnapshots int                         `json:"remainsnapshots"`
-	RevisionCounter int64                       `json:"revisioncounter, string"`
+	RevisionCounter int64                       `json:"revisioncounter,string"`
 }
 
 type CreateInput struct {
@@ -76,7 +76,7 @@ type PrepareRemoveDiskOutput struct {
 
 type RevisionCounter struct {
 	client.Resource
-	Counter int64 `json:"counter, string"`
+	Counter int64 `json:"counter,string"`
 }
 
 func NewReplica(context *api.ApiContext, state replica.State, info replica.Info, rep *replica.Replica) *Replica {


### PR DESCRIPTION
This PR fixes the following:
1. Docker has forbidden the older download url so `make` is failing
2. `go get golang.org/x/lint/golint` command fails while running `make` ( Ref: golang/go#28291)
```
error:
golang.org/x/tools/go/internal/gcimporter /go/src/golang.org/x/tools/go/internal/gcimporter/bexport.go:212: obj.IsAlias undefined (type *types.TypeName has no field or method IsAlias)
```
3. errors produced by go vet
4. integration tests

Update the url to download docker and dependencies required to run docker (1).
It also update the go version (1.8.3 to 1.10.3) since its not supported (2).
Fix the issues due to go version change (3) and integration tests (4).

Signed-off-by: Utkarsh Mani Tripathi <utkarshmani1997@gmail.com>