### PR TITLE
cli: Fix `Inconsistent snapshot` caused by different sizes

### DIFF
--- a/sync/sync.go
+++ b/sync/sync.go
@@ -552,9 +552,9 @@ func GetSnapshotsInfo(replicas []rest.Replica) (map[string]replica.DiskInfo, err
 			if new.Created != old.Created {
 				new.Created = old.Created
 			}
-			// VolumeHead is being written, so size can be slightly
-			// different.
-			if k == VolumeHeadName && new.Size != old.Size {
+			// The actual size is filesystem implementation depended. It cannot
+			// be used to check the data integrity.
+			if new.Size != old.Size {
 				new.Size = old.Size
 			}
 			if !reflect.DeepEqual(new, old) {


### PR DESCRIPTION
In the end, the real size of a sparse file is implementation depended and not
guarantee to be the minimal possible value. So it cannot be used to check data
integrity.

https://github.com/rancher/longhorn/issues/321