### PR TITLE
rpc: Reduce timeout for read/write to avoid block layer error

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -15,10 +15,10 @@ var (
 	ErrRWTimeout   = errors.New("r/w timeout")
 	ErrPingTimeout = errors.New("Ping timeout")
 
-	opRetries      = 4
-	opReadTimeout  = 15 * time.Second // client read
-	opWriteTimeout = 15 * time.Second // client write
-	opPingTimeout  = 20 * time.Second
+	opRetries      = 2
+	opReadTimeout  = 4 * time.Second // client read
+	opWriteTimeout = 4 * time.Second // client write
+	opPingTimeout  = 8 * time.Second
 )
 
 //Client replica client


### PR DESCRIPTION
The default error timeout for iscsi is 15 seconds. If the data plane of Longhorn
took too long to decide the replica is error, iscsi level timeout error would be
triggered and the volume may be remounted as read-only. So all the retry must be
done before hitting that time limit.

Reduce retry to 2 times, and retry timeout to 4 seconds. It would take (2 + 1) * 4
= 12 seconds before engine declare the replica is error.

See `node.session.err_timeo.abort_timeout` in /etc/iscsi/iscsi.d for the error
timeout setting for iscsi initiator.

Fixs https://github.com/rancher/longhorn/issues/380