### PR TITLE
frontend: cleanup existing block device by default

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -82,7 +82,7 @@ RUN cd /usr/src && \
 RUN cd /go/src/github.com/rancher && \
     git clone https://github.com/rancher/longhorn-engine-launcher.git && \
     cd longhorn-engine-launcher && \
-    git checkout d7e29231e81fb5853f5d384d6933c96ea6ad3697 && \
+    git checkout ff2fd2ecdff7d48693738071c3b14c597c46ddb7 && \
     go build && \
     cp longhorn-engine-launcher /usr/local/bin
 

--- a/frontend/tcmu/frontend.go
+++ b/frontend/tcmu/frontend.go
@@ -14,7 +14,10 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/pkg/errors"
+
 	"github.com/rancher/longhorn-engine/types"
+	"github.com/rancher/longhorn-engine/util"
 )
 
 const (
@@ -129,7 +132,10 @@ func createDevice(volume string) error {
 	dev := devPath + volume
 
 	if _, err := os.Stat(dev); err == nil {
-		return fmt.Errorf("Device %s already exists, can not create", dev)
+		logrus.Warnf("Device %s already exists, clean it up", dev)
+		if err := util.RemoveDevice(dev); err != nil {
+			return errors.Wrapf(err, "cannot cleanup block device file %v", dev)
+		}
 	}
 
 	tgt, _ := getScsiPrefixAndWnn(volume)

--- a/frontend/tgt/frontend.go
+++ b/frontend/tgt/frontend.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/pkg/errors"
 
 	"github.com/rancher/longhorn-engine/frontend/socket"
 	"github.com/rancher/longhorn-engine/iscsi"
@@ -116,7 +117,10 @@ func (t *Tgt) createDev() error {
 
 	dev := t.getDev()
 	if _, err := os.Stat(dev); err == nil {
-		return fmt.Errorf("Device %s already exists, can not create", dev)
+		logrus.Warnf("Device %s already exists, clean it up", dev)
+		if err := util.RemoveDevice(dev); err != nil {
+			return errors.Wrapf(err, "cannot cleanup block device file %v", dev)
+		}
 	}
 
 	if err := util.DuplicateDevice(t.scsiDevice.Device, dev); err != nil {


### PR DESCRIPTION
If the previous run failed to cleanup the device, it shouldn't become a
show stopper.

https://github.com/rancher/longhorn/issues/401