### PR TITLE
Fix creating backup would temporarily change the volume meta head

### DIFF
--- a/replica/replica.go
+++ b/replica/replica.go
@@ -136,6 +136,7 @@ func construct(readonly bool, size, sectorSize int64, dir, head string, backingF
 		activeDiskData:  make([]*disk, 1),
 		diskData:        make(map[string]*disk),
 		diskChildrenMap: map[string]map[string]bool{},
+		readOnly:        readonly,
 	}
 	r.info.Size = size
 	r.info.SectorSize = sectorSize

--- a/replica/revision_counter.go
+++ b/replica/revision_counter.go
@@ -56,6 +56,10 @@ func (r *Replica) openRevisionFile(isCreate bool) error {
 }
 
 func (r *Replica) initRevisionCounter() error {
+	if r.readOnly {
+		return nil
+	}
+
 	r.revisionLock.Lock()
 	defer r.revisionLock.Unlock()
 


### PR DESCRIPTION
https://github.com/rancher/longhorn/issues/412

The current code ignored temporarily replica object's `readonly`
properity, result in rewriting the volume metadata file by mistake
while create backup.

But the volume would normally restored to correct situation because
replica.Close() call would write the correct replica info in memory to
the disk. That's why normally this issue won't be exposed. But in the
case of one replica wasn't closed properly, the corrupted volume
metadata would be shown upon restart, result in snapshot failure etc in
the future.

The step to recover the data would be provided in the issue above.