### PR TITLE
Setting the right privileges for block devices

### DIFF
--- a/frontend/tcmu/frontend.go
+++ b/frontend/tcmu/frontend.go
@@ -127,7 +127,7 @@ func PostEnableTcmu(volume string) error {
 }
 
 func createDevice(volume string) error {
-	os.MkdirAll(devPath, 0700)
+	os.MkdirAll(devPath, 0755)
 
 	dev := devPath + volume
 
@@ -196,7 +196,7 @@ func createDevice(volume string) error {
 }
 
 func mknod(device string, major, minor int) error {
-	var fileMode os.FileMode = 0600
+	var fileMode os.FileMode = 0660
 	fileMode |= syscall.S_IFBLK
 	dev := int((major << 8) | (minor & 0xff) | ((minor & 0xfff00) << 12))
 

--- a/frontend/tgt/frontend.go
+++ b/frontend/tgt/frontend.go
@@ -111,7 +111,7 @@ func (t *Tgt) startScsiDevice() error {
 }
 
 func (t *Tgt) createDev() error {
-	if err := os.MkdirAll(DevPath, 0700); err != nil {
+	if err := os.MkdirAll(DevPath, 0755); err != nil {
 		logrus.Fatalln("Cannot create directory ", DevPath)
 	}
 

--- a/util/util.go
+++ b/util/util.go
@@ -106,11 +106,14 @@ func DuplicateDevice(src, dest string) error {
 	if err := mknod(dest, major, minor); err != nil {
 		return fmt.Errorf("Cannot duplicate device %s to %s", src, dest)
 	}
+	if err := os.Chmod(dest, 0660); err != nil {
+		return fmt.Errorf("Couldn't change permission of the device %s: %s", dest, err)
+	}
 	return nil
 }
 
 func mknod(device string, major, minor int) error {
-	var fileMode os.FileMode = 0600
+	var fileMode os.FileMode = 0660
 	fileMode |= unix.S_IFBLK
 	dev := int((major << 8) | (minor & 0xff) | ((minor & 0xfff00) << 12))
 


### PR DESCRIPTION
Earlier the device nodes were getting created with 0600 permissions. However, non longhorn block devices had 0660 permission assigned to them.
The following code changes modify the permission from 0600 to 0660. However, unix.Mknod was creating a block device with 0640 instead of 0660.
This could be perhaps due to umask being set to 0022. Hence, we're using os.Chmod to forcefully change the file permissions to 0660.