### PR TITLE
controller: perform sync before snapshot

### DIFF
--- a/controller/control.go
+++ b/controller/control.go
@@ -142,6 +142,11 @@ func (c *Controller) Snapshot(name string, labels map[string]string) (string, er
 		return "", fmt.Errorf("Too many snapshots created")
 	}
 
+	// We perform a system level sync here. Can be improved for the filesystem of block device later
+	if _, err := util.Execute("sync", ""); err != nil {
+		logrus.Errorf("WARNING: continue to snapshot for %v, but sync failed: %v", name, err)
+	}
+
 	created := util.Now()
 	if err := c.handleErrorNoLock(c.backend.Snapshot(name, true, created, labels)); err != nil {
 		return "", err


### PR DESCRIPTION
Make sure the data in the filesystem cache has been flushed.

This has a potentially problem is `sync` blocked for any reason. It can
be blocked due to failed to flush the cache for other block devices.
Currently we cannot separate them out.

https://github.com/rancher/longhorn/issues/507