### PR TITLE
Revert "Configure drone to publish to docker hub"

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -17,25 +17,6 @@ steps:
   - name: socket
     path: /var/run/docker.sock
 
-- name: docker-publish-master
-  pull: default
-  image: plugins/docker
-  settings:
-    context: package/
-    custom_dns: 1.1.1.1
-    dockerfile: package/Dockerfile
-    password:
-      from_secret: docker_password
-    repo: rancher/longhorn-engine
-    tag: master
-    username:
-      from_secret: docker_username
-  when:
-    branch:
-    - master
-    event:
-    - push
-
 volumes:
 - name: socket
   host:


### PR DESCRIPTION
Reverts rancher/longhorn-engine#360

It broke the drone.